### PR TITLE
(AI slop) autCongr is continuous

### DIFF
--- a/Iwasawalib/Algebra/Algebra/Equiv.lean
+++ b/Iwasawalib/Algebra/Algebra/Equiv.lean
@@ -20,7 +20,28 @@ namespace AlgEquiv
 /-- TODO: go mathlib -/
 theorem continuous_autCongr {R A₁ A₂ : Type*} [Field R] [Field A₁] [Field A₂]
     [Algebra R A₁] [Algebra R A₂] (ϕ : A₁ ≃ₐ[R] A₂) : Continuous (autCongr ϕ) := by
-  sorry
+  apply MonoidHom.continuous_of_continuousAt_one (autCongr ϕ).toMonoidHom
+  rw [Filter.HasBasis.tendsto_iff (galGroupBasis R A₁).nhds_one_hasBasis
+      (galGroupBasis R A₂).nhds_one_hasBasis]
+  intro ⟨K₂, hK₂⟩ _
+  refine ⟨⟨K₂.comap ϕ.toAlgHom, ?_⟩, trivial, ?_⟩
+  · exact Module.Finite.of_injective
+      ((ϕ.toAlgHom.toLinearMap.restrict
+        (p := (K₂.comap ϕ.toAlgHom).toSubalgebra.toSubmodule)).codRestrict
+        K₂.toSubalgebra.toSubmodule (by
+          intro ⟨x, hx⟩
+          simp [IntermediateField.mem_comap] at hx
+          exact hx)) (by
+        intro ⟨a, ha⟩ ⟨b, hb⟩ h
+        simp at h
+        exact Subtype.ext (ϕ.injective h))
+  · intro σ hσ
+    simp only [Set.mem_preimage]
+    intro x hx
+    simp [autCongr]
+    have := hσ (ϕ.symm x) (by simp [IntermediateField.mem_comap]; exact hx)
+    simp at this
+    exact this
 
 /-- Continuous version of `AlgEquiv.autCongr`. TODO: go mathlib -/
 @[simps! apply]

--- a/Iwasawalib/Algebra/Algebra/Equiv.lean
+++ b/Iwasawalib/Algebra/Algebra/Equiv.lean
@@ -6,6 +6,7 @@ Authors: Jz Pan
 module
 
 public import Mathlib.FieldTheory.Galois.Profinite
+public import Iwasawalib.Topology.Algebra.Group.Basic
 
 @[expose] public section
 
@@ -13,43 +14,39 @@ public import Mathlib.FieldTheory.Galois.Profinite
 
 # Supplementary results for isomorphisms of Galois groups induced by ring isomorphisms
 
+Maybe these should be in mathlib.
+
 -/
 
 namespace AlgEquiv
 
-/-- TODO: go mathlib -/
-theorem continuous_autCongr {R A₁ A₂ : Type*} [Field R] [Field A₁] [Field A₂]
-    [Algebra R A₁] [Algebra R A₂] (ϕ : A₁ ≃ₐ[R] A₂) : Continuous (autCongr ϕ) := by
-  apply MonoidHom.continuous_of_continuousAt_one (autCongr ϕ).toMonoidHom
-  rw [Filter.HasBasis.tendsto_iff (galGroupBasis R A₁).nhds_one_hasBasis
-      (galGroupBasis R A₂).nhds_one_hasBasis]
-  intro ⟨K₂, hK₂⟩ _
-  refine ⟨⟨K₂.comap ϕ.toAlgHom, ?_⟩, trivial, ?_⟩
-  · exact Module.Finite.of_injective
-      ((ϕ.toAlgHom.toLinearMap.restrict
-        (p := (K₂.comap ϕ.toAlgHom).toSubalgebra.toSubmodule)).codRestrict
-        K₂.toSubalgebra.toSubmodule (by
-          intro ⟨x, hx⟩
-          simp [IntermediateField.mem_comap] at hx
-          exact hx)) (by
-        intro ⟨a, ha⟩ ⟨b, hb⟩ h
-        simp at h
-        exact Subtype.ext (ϕ.injective h))
-  · intro σ hσ
-    simp only [Set.mem_preimage]
-    intro x hx
-    simp [autCongr]
-    have := hσ (ϕ.symm x) (by simp [IntermediateField.mem_comap]; exact hx)
-    simp at this
-    exact this
+theorem continuous_autCongr
+    {R A₁ A₂ : Type*} [Field R] [Field A₁] [Field A₂] [Algebra R A₁] [Algebra R A₂]
+    (ϕ : A₁ ≃ₐ[R] A₂) : Continuous ϕ.autCongr := by
+  refine ϕ.autCongr.toMonoidHom.continuous_iff.2 fun s h1 hs ↦ ?_
+  obtain ⟨L, _, hle⟩ := (krullTopology_mem_nhds_one_iff _ _ s).1 (isOpen_iff_mem_nhds.1 hs _ h1)
+  refine ⟨L.fixingSubgroup.comap ϕ.autCongr.toMonoidHom, one_mem _, ?_, by simpa⟩
+  have := (L.equivMap ϕ.symm.toAlgHom).toLinearEquiv.finiteDimensional
+  convert (L.map ϕ.symm.toAlgHom).fixingSubgroup_isOpen
+  ext f
+  simp only [MulEquiv.toMonoidHom_eq_coe, Subgroup.mem_comap, MonoidHom.coe_coe, autCongr_apply,
+    IntermediateField.mem_fixingSubgroup_iff, trans_apply, toAlgHom_eq_coe]
+  change _ ↔ ∀ x ∈ (L.map _).toSubalgebra, _
+  simp only [IntermediateField.toSubalgebra_map, Subalgebra.mem_map, and_imp, forall_exists_index,
+    IntermediateField.mem_toSubalgebra, AlgHom.coe_coe, forall_apply_eq_imp_iff₂]
+  refine ⟨fun h x hx ↦ ?_, fun h x hx ↦ ?_⟩
+  · apply_fun _ using ϕ.injective
+    simp [h x hx]
+  · simp [h x hx]
 
-/-- Continuous version of `AlgEquiv.autCongr`. TODO: go mathlib -/
-@[simps! apply]
-noncomputable def autContinuousCongr {R A₁ A₂ : Type*} [Field R] [Field A₁] [Field A₂]
-    [Algebra R A₁] [Algebra R A₂] (ϕ : A₁ ≃ₐ[R] A₂) : Gal(A₁/R) ≃ₜ* Gal(A₂/R) where
-  toMulEquiv := autCongr ϕ
-  continuous_toFun := continuous_autCongr ϕ
-  continuous_invFun := continuous_autCongr ϕ.symm
+/-- Continuous version of `AlgEquiv.autCongr`. -/
+@[simps! apply toMulEquiv]
+def continuousAutCongr
+    {R A₁ A₂ : Type*} [Field R] [Field A₁] [Field A₂] [Algebra R A₁] [Algebra R A₂]
+    (ϕ : A₁ ≃ₐ[R] A₂) : (A₁ ≃ₐ[R] A₁) ≃ₜ* A₂ ≃ₐ[R] A₂ where
+  toMulEquiv := ϕ.autCongr
+  continuous_toFun := ϕ.continuous_autCongr
+  continuous_invFun := ϕ.symm.continuous_autCongr
 
 section autCongrOfSurjective
 

--- a/Iwasawalib/FieldTheory/Galois/Abelian.lean
+++ b/Iwasawalib/FieldTheory/Galois/Abelian.lean
@@ -80,7 +80,7 @@ theorem continuous_piRestrictNormalHom' (E' : IntermediateField F K) (h : ⨆ i,
   have h' (i : ι) : E i ≤ E' := h ▸ le_iSup E i
   have (i : ι) : Normal F (restrict (h' i)) := .of_algEquiv (restrict_algEquiv (h' i))
   let g := Homeomorph.piCongrRight fun i ↦
-    (restrict_algEquiv (h' i)).symm.autContinuousCongr.toHomeomorph
+    (restrict_algEquiv (h' i)).symm.continuousAutCongr.toHomeomorph
   exact g.continuous.comp (continuous_piRestrictNormalHom fun i ↦ restrict (h' i))
 
 theorem injective_piRestrictNormalHom' (E' : IntermediateField F K) (h : ⨆ i, E i = E') :

--- a/Iwasawalib/FieldTheory/ZpExtension/Basic.lean
+++ b/Iwasawalib/FieldTheory/ZpExtension/Basic.lean
@@ -5,12 +5,12 @@ Authors: Jz Pan
 -/
 module
 
+public import Iwasawalib.Algebra.Algebra.Equiv
 public import Mathlib.FieldTheory.Galois.Abelian
 public import Mathlib.FieldTheory.Galois.Infinite
 public import Mathlib.FieldTheory.Galois.Profinite
 public import Iwasawalib.NumberTheory.Padics.EquivMvZp
 public import Mathlib.Topology.Algebra.ClopenNhdofOne
-public import Iwasawalib.Topology.Algebra.Group.Basic
 
 @[expose] public section
 
@@ -26,36 +26,6 @@ use `Nonempty (MvZpExtension p ι K Kinf)`. As a special case, to state that `Ki
 a `ℤₚᵈ`-extension, use `Nonempty (MvZpExtension p (Fin d) K Kinf)`.
 
 -/
-
-/-! ### Maybe these should be in mathlib -/
-
-theorem AlgEquiv.continuous_autCongr
-    {R A₁ A₂ : Type*} [Field R] [Field A₁] [Field A₂] [Algebra R A₁] [Algebra R A₂]
-    (ϕ : A₁ ≃ₐ[R] A₂) : Continuous ϕ.autCongr := by
-  refine ϕ.autCongr.toMonoidHom.continuous_iff.2 fun s h1 hs ↦ ?_
-  obtain ⟨L, _, hle⟩ := (krullTopology_mem_nhds_one_iff _ _ s).1 (isOpen_iff_mem_nhds.1 hs _ h1)
-  refine ⟨L.fixingSubgroup.comap ϕ.autCongr.toMonoidHom, one_mem _, ?_, by simpa⟩
-  have := (L.equivMap ϕ.symm.toAlgHom).toLinearEquiv.finiteDimensional
-  convert (L.map ϕ.symm.toAlgHom).fixingSubgroup_isOpen
-  ext f
-  simp only [MulEquiv.toMonoidHom_eq_coe, Subgroup.mem_comap, MonoidHom.coe_coe, autCongr_apply,
-    IntermediateField.mem_fixingSubgroup_iff, trans_apply, toAlgHom_eq_coe]
-  change _ ↔ ∀ x ∈ (L.map _).toSubalgebra, _
-  simp only [IntermediateField.toSubalgebra_map, Subalgebra.mem_map, and_imp, forall_exists_index,
-    IntermediateField.mem_toSubalgebra, AlgHom.coe_coe, forall_apply_eq_imp_iff₂]
-  refine ⟨fun h x hx ↦ ?_, fun h x hx ↦ ?_⟩
-  · apply_fun _ using ϕ.injective
-    simp [h x hx]
-  · simp [h x hx]
-
-/-- Continuous version of `AlgEquiv.autCongr`. -/
-@[simps! apply toMulEquiv]
-def AlgEquiv.continuousAutCongr
-    {R A₁ A₂ : Type*} [Field R] [Field A₁] [Field A₂] [Algebra R A₁] [Algebra R A₂]
-    (ϕ : A₁ ≃ₐ[R] A₂) : (A₁ ≃ₐ[R] A₁) ≃ₜ* A₂ ≃ₐ[R] A₂ where
-  toMulEquiv := ϕ.autCongr
-  continuous_toFun := ϕ.continuous_autCongr
-  continuous_invFun := ϕ.symm.continuous_autCongr
 
 /-! ### `ℤₚᵈ`-extension -/
 

--- a/Iwasawalib/Topology/Algebra/Group/Basic.lean
+++ b/Iwasawalib/Topology/Algebra/Group/Basic.lean
@@ -15,7 +15,8 @@ public import Mathlib.Topology.Algebra.Group.Basic
 
 -/
 
-@[to_additive]
+/-- See also `MonoidHom.uniformContinuous_of_continuousAt_one` -/
+@[to_additive /-- See also `AddMonoidHom.uniformContinuous_of_continuousAt_zero` -/]
 theorem MonoidHom.continuous_iff {G H : Type*} [Group G] [Monoid H]
     [TopologicalSpace G] [TopologicalSpace H] [ContinuousMul G] [ContinuousMul H] (f : G →* H) :
     Continuous f ↔ ∀ s : Set H, 1 ∈ s → IsOpen s →


### PR DESCRIPTION
Proof strategy: The Krull topology on Gal(A/R) is defined via galGroupBasis, whose basic open neighborhoods of 1 are the fixing subgroups of finite-dimensional intermediate fields. To show autCongr ϕ is continuous:



Apply MonoidHom.continuous_of_continuousAt_one to reduce to continuity at 1.

Use the filter basis characterization: for each finite-dimensional intermediate field K₂ of A₂/R, find a finite-dimensional intermediate field of A₁/R whose fixing subgroup maps into the fixing subgroup of K₂.

Take K₂.comap ϕ.toAlgHom — the preimage of K₂ under ϕ. This is finite-dimensional (shown via an injective linear map into K₂ using ϕ), and its fixing subgroup maps into the fixing subgroup of K₂ (since autCongr ϕ σ fixes K₂ whenever σ fixes ϕ⁻¹(K₂)).

---

This looks better, can be refactored quite easily.